### PR TITLE
fix: remove triple space in event name

### DIFF
--- a/parsepdf.py
+++ b/parsepdf.py
@@ -31,7 +31,7 @@ def main():
 
                 try:
                     name_match = re.search(NAME_REGEX, text)
-                    name = name_match.group(1).replace('\n', ' ').strip()
+                    name = name_match.group(1).replace('\n', '').strip()
                     name = re.sub(r'[\\/:*?\"<>|]', '', name)
                     print(f"Found {name} at page {i + 1}")
 

--- a/parsepdf.py
+++ b/parsepdf.py
@@ -41,7 +41,8 @@ def main():
                     entries.append([name, i])
                     
                 except AttributeError:
-                    break
+                    print(f"[DEBUG]: marker_match ('{marker_match.string}') is true but name_match is None")
+                    continue
 
         entries[-1].append(n_pages - 1)
 

--- a/parsepdf.py
+++ b/parsepdf.py
@@ -3,7 +3,7 @@ import os
 import re
 
 # Variables
-PATH = 'Engg Week 2024 Handbook V1.pdf'
+PATH = './[EASL] EW 2025 Handbook Version 1.pdf'
 OUTPATH = 'output/'
 
 # Consts
@@ -29,15 +29,19 @@ def main():
             if marker_match:
                 count += 1
 
-                name_match = re.search(NAME_REGEX, text)
-                name = name_match.group(1).replace('\n', ' ').strip()
-                name = re.sub(r'[\\/:*?\"<>|]', '', name)
-                print(f"Found {name} at page {i + 1}")
+                try:
+                    name_match = re.search(NAME_REGEX, text)
+                    name = name_match.group(1).replace('\n', ' ').strip()
+                    name = re.sub(r'[\\/:*?\"<>|]', '', name)
+                    print(f"Found {name} at page {i + 1}")
 
-                if entries:
-                    entries[-1].append(i - 1)
+                    if entries:
+                        entries[-1].append(i - 1)
 
-                entries.append([name, i])
+                    entries.append([name, i])
+                    
+                except AttributeError:
+                    break
 
         entries[-1].append(n_pages - 1)
 


### PR DESCRIPTION
This PR resolves an issue found where event names are read out with triple spaces. This is done by changing line 33 in the script to render all `\n` characters to no-characters instead of space (` `) characters as previous.

This also resolves an issue that arises when `marker_match` exists, but for some reason `name_match` does not by catching the `AttributeError` that arises and continuing generation from there and printing out a debug message. This should be an item to be fixed by a later PR.